### PR TITLE
really fast camelcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Emacs
+*~

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # go-camelcase
 
 Fast camelcase implementation that avoids Go's regexps. Direct fork of our [snakecase](https://github.com/segmentio/go-snakecase) implementation.

--- a/camel.go
+++ b/camel.go
@@ -3,65 +3,71 @@
 //
 package camelcase
 
-import "strings"
-
-// camelCase the given `str`.
-func Camelcase(str string) string {
-	var b [1024]byte
-	max := 1024
-	l := len(str)
-	ret := ""
-	bi := 0
+// Camelcase the given string.
+func Camelcase(s string) string {
+	b := make([]byte, 0, 64)
+	l := len(s)
 	i := 0
-	first := true
 
 	for i < l {
 
-		for i < l && !isWord(str[i]) {
+		// skip leading bytes that aren't letters or digits
+		for i < l && !isWord(s[i]) {
 			i++
 		}
 
-		for i < l && isUpper(str[i]) {
-			if bi < max {
-				b[bi] = str[i]
-				bi++
+		// set the first byte to uppercase if it needs to
+		if i < l {
+			c := s[i]
+
+			// simply append contiguous digits
+			if isDigit(c) {
+				for i < l {
+					if c = s[i]; !isDigit(c) {
+						break
+					}
+					b = append(b, c)
+					i++
+				}
+				continue
 			}
-			i++
-		}
 
-		for i < l && isPart(str[i]) {
-			if bi < max {
-				b[bi] = str[i]
-				bi++
+			// the sequence starts with and uppercase letter, we append
+			// all following uppercase letters as equivalent lowercases
+			if isUpper(c) {
+				b = append(b, c)
+				i++
+
+				for i < l {
+					if c = s[i]; !isUpper(c) {
+						break
+					}
+					b = append(b, toLower(c))
+					i++
+				}
+
+			} else {
+				b = append(b, toUpper(c))
+				i++
 			}
-			i++
-		}
 
-		for i < l && !isWord(str[i]) {
-			i++
+			// append all trailing lowercase letters
+			for i < l {
+				if c = s[i]; !isLower(c) {
+					break
+				}
+				b = append(b, c)
+				i++
+			}
 		}
-
-		if first {
-			ret += strings.ToLower(string(b[:bi]))
-			first = false
-		} else {
-			// .ToTitle is weird in Go
-			ret += strings.ToUpper(string(b[:1]))
-			ret += strings.ToLower(string(b[1:bi]))
-		}
-
-		bi = 0
 	}
 
-	if len(ret) > 0 {
-		ret = ret[:len(ret)]
+	// the first byte must always be lowercase
+	if len(b) != 0 {
+		b[0] = toLower(b[0])
 	}
 
-	return ret
-}
-
-func isPart(c byte) bool {
-	return isLower(c) || isDigit(c)
+	return string(b)
 }
 
 func isWord(c byte) bool {
@@ -82,4 +88,18 @@ func isLower(c byte) bool {
 
 func isDigit(c byte) bool {
 	return c >= '0' && c <= '9'
+}
+
+func toLower(c byte) byte {
+	if isUpper(c) {
+		return c + ('a' - 'A')
+	}
+	return c
+}
+
+func toUpper(c byte) byte {
+	if isLower(c) {
+		return c - ('a' - 'A')
+	}
+	return c
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,26 @@
 machine:
-  golang:
-    version: 1.3
+  services:
+    - docker
+  environment:
+    PKG: ${CIRCLE_PROJECT_REPONAME}
+    URL: github.com/${CIRCLE_PROJECT_USERNAME}/${PKG}
+    DOCKER: >
+      docker run -i -t
+      -v ${GOPATH%%:*}:/go
+      -v ${HOME}/${PKG}:/go/src/${URL}
+      -v /var/run/docker.sock:/run/docker.sock
+      -v $(which docker):/usr/bin/docker:ro
+      -v $(which docker-compose):/usr/bin/docker-compose:ro
+      -w /go/src/${URL}
+
+dependencies:
+  pre:
+    - docker pull segment/golang:latest
+  override:
+    - ${DOCKER} -v ${HOME}/.ssh:/root/.ssh:ro segment/golang:latest get
 
 test:
   override:
-    - go test -v -cover
+    - ${DOCKER} segment/golang:latest vet lint test bench
+  post:
+    - ${DOCKER} segment/golang:latest build


### PR DESCRIPTION
@segmentio/infra 
@sperand-io 

Follow up of https://github.com/segmentio/go-snakecase/pull/1

Before:

```
$ go test -bench .
PASS
BenchmarkCamelcase-4      500000          2490 ns/op
ok      github.com/segmentio/go-camelcase   1.280s
```

After:

```
$ go test -bench .
PASS
BenchmarkCamelcase-4    10000000           192 ns/op
ok      github.com/segmentio/go-camelcase   2.126s
```

==> 12x 💃 
